### PR TITLE
Add tailscale-dev/deck-tailscale dir to PATH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,9 @@ yalc.lock
 # Ignore output folder
 
 backend/out
+
+# Ignore pnpm cache
+.pnpm-store/*
+
+# Ignore deck.json, which is developer-specific and stores the sensitive sudo password
+deck.json

--- a/main.py
+++ b/main.py
@@ -3,6 +3,8 @@ import decky_plugin
 import os
 
 os.environ['XDG_RUNTIME_DIR'] = '/run/user/1000'
+# Add the install directory used by https://github.com/tailscale-dev/deck-tailscale to the PATH
+os.environ['PATH'] += ':/opt/tailscale'
 
 
 class Plugin:

--- a/main.py
+++ b/main.py
@@ -3,9 +3,13 @@ import decky_plugin
 import os
 
 os.environ['XDG_RUNTIME_DIR'] = '/run/user/1000'
-# Add the install directory used by https://github.com/tailscale-dev/deck-tailscale to the PATH
-os.environ['PATH'] += ':/opt/tailscale'
 
+# Add install directories used by https://github.com/tailscale-dev/deck-tailscale
+# and Nix (https://github.com/saumya-banthia/tailscale-control/issues/7) to the PATH
+user_dirs = ['/opt/tailscale', '/home/deck/.nix-profile/bin']
+current_path = os.environ["PATH"].split(":")
+new_path = ":".join(current_path + [user_dir for user_dir in user_dirs if user_dir not in current_path])
+os.environ["PATH"] = new_path
 
 class Plugin:
     async def up(self):


### PR DESCRIPTION
As discussed in https://github.com/tailscale-dev/deck-tailscale/pull/15 and https://discord.com/channels/960281551428522045/1186652921186766898/1186663913878736937 we're changing the Tailscale setup on Steam Deck to install it in `/opt/tailscale`. One of the side-effects of this is the `tailscale` CLI not being available under `/usr` anymore, and Decky plugins can't rely on $PATH because Decky Loader doesn't start a login session (`/etc/profile`, `/etc/bash.bashrc` etc aren't available)

This PR adds the new path to the plugin's Python backend. It does it in a backwards-compatible way, so it'll work even if users don't upgrade their `tailscale-dev/deck-tailscale` install. Plus it adds a few minor local development quality-of-life improvements