### PR TITLE
Update DFL to 3.25

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,14 +39,15 @@
     "typescript": "^4.7.4"
   },
   "dependencies": {
-    "decky-frontend-lib": "^3.24.5",
+    "decky-frontend-lib": "^3.25.0",
     "react-icons": "^4.4.0"
   },
   "pnpm": {
     "peerDependencyRules": {
       "ignoreMissing": [
         "react",
-        "react-dom"
+        "react-dom",
+        "decky-frontend-lib"
       ]
     }
   }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -24,12 +24,13 @@ export default defineConfig({
     })
   ],
   context: 'window',
-  external: ['react', 'react-dom'],
+  external: ['react', 'react-dom', 'decky-frontend-lib'],
   output: {
     file: 'dist/index.js',
     globals: {
       react: 'SP_REACT',
       'react-dom': 'SP_REACTDOM',
+      'decky-frontend-lib': 'DFL',
     },
     format: 'iife',
     exports: 'default',


### PR DESCRIPTION
See https://github.com/SteamDeckHomebrew/decky-loader/issues/597#issuecomment-1987138946

Plugin is currently broken on latest steam/steamos

(Changes tested locally, but not thoroughly. Plugin loads, switches work) 